### PR TITLE
[FEAT] (chat) 채팅관련 JWT인증기능 추가

### DIFF
--- a/src/main/java/com/example/lastproject/config/JwtHandshakeInterceptor.java
+++ b/src/main/java/com/example/lastproject/config/JwtHandshakeInterceptor.java
@@ -1,0 +1,70 @@
+package com.example.lastproject.config;
+
+import com.example.lastproject.domain.auth.entity.AuthUser;
+import com.example.lastproject.domain.user.enums.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class JwtHandshakeInterceptor implements HandshakeInterceptor {
+
+    private final JwtUtil jwtUtil;
+
+    /**
+     * 채팅창 접속시, 인증된 사용자만 채팅을 사용할수 있도록 JWT검증을 수행하는 메서드
+     * 모든 HTTP 요청에서 JWT를 통해 인증 절차를 거치도록 무상태 서비스 구성을 해두었기 때문에, WebSocket 요청에서도 동일하게 JWT 인증을 적용하는 것이 일관된 보안 체계를 유지
+     */
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) {
+
+        // URL 파라미터에서 JWT 토큰 추출
+        String token = request.getURI().getQuery();
+        String jwt = null;
+
+        // 파라미터가 "token=..." 형식인지 확인하여 JWT 값 추출
+        if (token != null && token.startsWith("token=")) {
+            jwt = token.substring("token=".length());
+        }
+
+        // JWT인증
+        if (jwt != null) {
+            try {
+
+                Claims claims = jwtUtil.extractClaims(jwt);
+                Long userId = Long.valueOf(claims.getSubject());
+                String email = claims.get("email", String.class);
+                UserRole userRole = UserRole.of(claims.get("userRole", String.class));
+
+                // AuthUser 생성 후 WebSocket 세션에 저장
+                AuthUser authUser = new AuthUser(userId, email, userRole);
+                attributes.put("authUser", authUser);
+
+                return true;
+
+            } catch (SecurityException | MalformedJwtException | ExpiredJwtException e) {
+                response.setStatusCode(HttpStatusCode.valueOf(401));
+            } catch (UnsupportedJwtException e) {
+                response.setStatusCode(HttpStatusCode.valueOf(400));
+            } catch (Exception e) {
+                response.setStatusCode(HttpStatusCode.valueOf(500));
+            }
+        }
+        return false; // JWT 토큰이 없거나 잘못된 경우 연결 거부
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+    }
+
+}

--- a/src/main/java/com/example/lastproject/config/WebSocketConfig.java
+++ b/src/main/java/com/example/lastproject/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.example.lastproject.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
@@ -14,7 +15,10 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtHandshakeInterceptor jwtHandshakeInterceptor;
 
     /**
      * 클라이언트가 Websocket서버에 접속하기 위해 사용할 메서드
@@ -25,7 +29,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         //cors정책과 충돌하지 않기 위해 patterns로 수정
-        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").withSockJS();
+        //JWT인증을 위해 Interceptor 추가
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*").addInterceptors(jwtHandshakeInterceptor).withSockJS();
     }
 
     /**

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -21,11 +21,14 @@ function connect(event) {
     username = document.querySelector('#name').value.trim();
     chatRoomId = document.querySelector('#chatRoomId').value.trim();
 
+    const jwtToken = '인증된jwt토큰';
+    localStorage.setItem('jwtToken', jwtToken);
+
     if(username && chatRoomId) {
         usernamePage.classList.add('hidden');
         chatPage.classList.remove('hidden');
 
-        var socket = new SockJS('/ws');
+        var socket = new SockJS(`/ws?token=${jwtToken}`);
         stompClient = Stomp.over(socket);
 
         stompClient.connect({}, onConnected, onError);


### PR DESCRIPTION
1. HandshakeInterceptor를 활용한 JWT인증기능 추가
- WebSocket 요청에서도 동일하게 JWT 인증을 적용하여 Stateless한 일관된 보안 체계를 유지
- 메세지별로 디테일하게 관리할 필요보다는, 초기에 사용자 인증과정을 거쳐 채팅창을 사용하게 하는게 목적적합하다고 판단
  -  ChannelInterceptor대신 HandshakeInterceptor 사용
  - WebSocket 프로토콜 자체는 HTTP 헤더를 전송하는 것을 지원하지 않기 때문에, 이를 해결하기 위해 URL 파라미터로 구현